### PR TITLE
PixelPropsUtils: Added HDR support for Netflix

### DIFF
--- a/core/java/com/android/internal/util/spiceos/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/spiceos/PixelPropsUtils.java
@@ -48,8 +48,8 @@ public class PixelPropsUtils {
     private static final Map<String, ArrayList<String>> propsToKeep;
     private static final String[] extraPackagesToChange = {
         "com.android.chrome",
-        "com.breel.wallpapers20"
-
+        "com.breel.wallpapers20",
+        "com.netflix.mediaclient"
     };
 
     private static final String[] packagesToChangeCOD = {


### PR DESCRIPTION
Requirements: Device must be in Widevine L1 certification after installing custom OS to get the HDR support in NETFLIX.